### PR TITLE
Switch to direct url install of rclone instead of apt

### DIFF
--- a/odoo/12.0/Dockerfile
+++ b/odoo/12.0/Dockerfile
@@ -27,8 +27,8 @@ RUN apt update \
         python3-wheel \
         python3-xlrd \
         rsync \
-        xz-utils \
         unzip \
+        xz-utils \
     && curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb \
     && echo 'f1689a1b302ff102160f2693129f789410a1708a wkhtmltox.deb' | sha1sum -c - \
     && apt install -y --no-install-recommends ./wkhtmltox.deb \


### PR DESCRIPTION
We needed a newer version of rclone for v12. The one apt installs does not support azure blob. These changes install the 1.56 version.