### PR TITLE
[IMP] FrePPLe: Running migration with every start and not only recreation

### DIFF
--- a/frepple/6/entrypoint.sh
+++ b/frepple/6/entrypoint.sh
@@ -37,11 +37,11 @@ then
   echo "Creating $PGDATABASE databases"
   createdb $PGDATABASE
   echo "Create FrePPLe databases"
-  frepplectl migrate --noinput
   frepplectl createdatabase --database=scenario1
   frepplectl createdatabase --database=scenario2
   frepplectl createdatabase --database=scenario3
 fi
+frepplectl migrate --noinput
 
 echo "Configure atd"
 echo www-data > /etc/at.allow


### PR DESCRIPTION

Running frepple migration at every run adds a second or so to the container start, but it allows migrating the postgres database schema between frepple releases without data loss.

The frepple dockerfile has this equivalent: 
https://github.com/frePPLe/frepple/blob/bc3bfc057d91f94d9adee1f6445bb17adfdefd05/contrib/docker/entrypoint.sh#L34

Using the "frepplectl createdatabase" is an alternative to the createdb commands. It has the advantage of a) picking up the database names to be created from djangosettings.py (rather than hardcoding) and b) running as the database user configured in djangosettings (not relevant in isolated docker, but relevant if the postgres server also hosts other databases) 