### PR TITLE
[FIX] Odoo 16: use wkhtmltopdf 0.12.6.1 (with patched qt)

### DIFF
--- a/odoo/16.0/Dockerfile
+++ b/odoo/16.0/Dockerfile
@@ -27,8 +27,10 @@ RUN apt update \
         python3-wheel \
         python3-xlrd \
         python3-xlwt \
-        wkhtmltopdf \
         xz-utils \
+    && curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb \
+    && echo '800eb1c699d07238fee77bf9df1556964f00ffcf wkhtmltox.deb' | sha1sum -c - \
+    && apt install -y --no-install-recommends ./wkhtmltox.deb \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Rclone


### PR DESCRIPTION
The packaged wkhtmltopdf 0.12.6.1 does not work well with Odoo.
I could see the error:
```
wkhtmltopdf: b'The switch --header-spacing, is not support using unpatched qt, and will be ignored.The switch --header-html, is not support using unpatched qt, and will be ignored.The switch --footer-html, is not support
using unpatched qt, and will be ignored.Exit with code 1, due to unknown error.\n' 
```

Using the qt patched version downloaded from Github seems to solve the issue.