### PR TITLE
Add frePPLe version 8 support, using frePPLe's docker image as base

### DIFF
--- a/frepple/8/docker-compose.yml
+++ b/frepple/8/docker-compose.yml
@@ -1,0 +1,77 @@
+version: "2"
+services:
+  frepple-db:
+    image: ursa/postgresql:latest
+    restart: always
+    environment:
+      - POSTGRES_DBNAME=postgres
+      - POSTGRES_USER=frepple
+      - POSTGRES_PASSWORD=frepple
+      - POSTGRES_DATA=/var/lib/postgresql/data/pgdata
+    volumes:
+      - "postgres-data:/var/lib/postgresql/data"
+
+  frepple-app:
+    build:
+      context: frepple
+    ports:
+      - "8080:80"
+    depends_on:
+      - frepple-db
+    environment:
+      - FREPPLE_ADMIN_EMAIL=support@opensourceintegrators.com
+      - FREPPLE_ADMIN_NAME=Open Source Integrators
+      - FREPPLE_SECRET_KEY=frepple-test
+      - FREPPLE_OPTIONS={}
+      - FREPPLE_CONN_MAX_AGE=60
+      - FREPPLE_TEST_NAME=test_frepple
+      - FREPPLE_LOGDIR=/var/log/frepple
+      - FREPPLE_SQL_ROLE=report_role
+        #- FREPPLE_PORT_DEFAULT=127.0.0.1:8002
+      - FREPPLE_LANGUAGE_CODE=en
+      - FREPPLE_GOOGLE_ANALYTICS=None
+      - FREPPLE_TIME_ZONE=UTC
+      - FREPPLE_SESSION_COOKIE_AGE=3600 * 24 * 3
+      - FREPPLE_ATTRIBUTES=[]
+      - FREPPLE_MAXMEMORYSIZE=None
+      - FREPPLE_MAXCPUTIME=None
+      - FREPPLE_MAXTOTALLOGFILESIZE=200
+      - FREPPLE_DEFAULT_USER_GROUP=None
+      - FREPPLE_DEFAULT_PAGESIZE=100
+      - FREPPLE_DEFAULT_THEME=earth
+        #- FREPPLE_PORT=8000
+      # Apps
+      - FREPPLE_INSTALLED_APPS_CUSTOM='freppledb.custom',
+      - FREPPLE_INSTALLED_APPS_FORECASTING=true
+      - FREPPLE_INSTALLED_APPS_INVENTORY=true
+      - FREPPLE_INSTALLED_APPS_ODOO=true
+      # PostgreSQL
+      - POSTGRES_DBNAME=frepple
+      - POSTGRES_HOST=frepple-db
+      - POSTGRES_USER=frepple
+      - POSTGRES_PASSWORD=frepple
+      # Email
+      - FREPPLE_EMAIL_USE_TLS=True
+      - FREPPLE_DEFAULT_FROM_EMAIL=example@example.com
+      - FREPPLE_SERVER_EMAIL=example@example.com
+      - FREPPLE_EMAIL_HOST_USER=example@example.com
+      - FREPPLE_EMAIL_HOST_PASSWORD=test
+      - FREPPLE_EMAIL_HOST='placeholder'
+        #- FREPPLE_EMAIL_PORT=465
+      # Selenium
+      - FREPPLE_SELENIUM_TESTS=chrome
+      - FREPPLE_SELENIUM_HEADLESS=True
+      # Odoo
+      - FREPPLE_ODOO_PASSWORD_DEFAULT=test
+      - FREPPLE_ODOO_PASSWORD_SCENARIO1=test
+      - FREPPLE_ODOO_PASSWORD_SCENARIO2=test
+      - FREPPLE_ODOO_PASSWORD_SCENARIO3=test
+      - FREPPLE_CSRF_COOKIE_SAMESITE=None
+      - FREPPLE_CSRF_COOKIE_SECURE=True
+      - FREPPLE_SESSION_COOKIE_SAMESITE=None
+      - FREPPLE_SESSION_COOKIE_SECURE=True
+
+
+volumes:
+  postgres-data:
+

--- a/frepple/8/frepple/Dockerfile
+++ b/frepple/8/frepple/Dockerfile
@@ -1,0 +1,38 @@
+#FROM 880063853698.dkr.ecr.us-west-2.amazonaws.com/strymon-frepple:frepple-8-0-3-official
+FROM ghcr.io/frepple/frepple-enterprise:8.0.3
+MAINTAINER Open Source Integrators <support@opensourceintegrators.com>
+
+
+# Update the PostgreSQL client to match the server
+ENV PGVERSION=14
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+    && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && apt update \
+    && apt install --no-install-recommends -y postgresql-client-$PGVERSION \
+    && rm -f /etc/apt/sources.list.d/pgdg.list \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Dockerize in order to use the djangosettings template
+ENV DOCKERIZE_VERSION v0.7.0
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget -O - https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar xzf - -C /usr/local/bin \
+    && apt-get autoremove -yqq --purge wget && rm -rf /var/lib/apt/lists/*
+
+# Install python and pip to install frePPLe requirements
+RUN apt-get install -y python3
+RUN apt-get update && apt-get -y install python3-pip
+
+# Copy files
+COPY entrypoint.sh /
+COPY templates /frepple/templates
+COPY requirements.txt /frepple/requirements.txt
+COPY license.xml /etc/frepple/
+
+# Install python3 modules
+RUN pip install -r /frepple/requirements.txt
+
+# Expose FrePPLe
+EXPOSE 80
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/frepple/8/frepple/charts/Chart.yaml
+++ b/frepple/8/frepple/charts/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+name: frepple
+version: 1.0
+appVersion: 8.0.3
+description: FrePPLe 8
+home: https://www.opensourceintegrators.com
+icon: https://github.com/ursais.png?width=64
+keywords:
+- advanced planning system
+- manufacturing
+- purchasing
+- distribution
+- planning
+- material requirement
+sources:
+- https://github.com/ursais/docker
+maintainers:
+- name: Open Source Integrators
+  email: support@opensourceintegrators.com
+engine: gotpl

--- a/frepple/8/frepple/charts/values.yaml
+++ b/frepple/8/frepple/charts/values.yaml
@@ -1,0 +1,9 @@
+name: frepple
+adminName: frepple
+adminEmail: admin@example.com
+secretKey: frepple
+secretWebtokenKey: frepple
+pgdatabase: frepple
+pghost: db
+pgpassword: frepple
+pguser: frepple

--- a/frepple/8/frepple/entrypoint.sh
+++ b/frepple/8/frepple/entrypoint.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -e
+
+# Set default value to environment variables
+export RUNNING_ENV="${RUNNING_ENV:='dev'}"
+
+# PostgreSQL
+export PGHOST="${POSTGRES_HOST:=db}"
+export PGPORT="${POSTGRES_PORT:=5432}"
+export PGUSER="${POSTGRES_USER:=frepple}"
+export PGPASSWORD="${POSTGRES_PASSWORD:=frepple}"
+export PGDATABASE="${POSTGRES_DBNAME:=false}"
+export DEFAULTDB="${DEFAULTDB:=postgres}"
+
+# Functions
+function config_frepple() {
+  echo "Configure FrePPLe"
+  dockerize -template $TEMPLATES/djangosettings.py.tmpl:/etc/frepple/djangosettings.py
+}
+
+# For dockerize
+export TEMPLATES=/frepple/templates
+config_frepple
+
+# Wait for database to be ready
+echo "Waiting for the database to be ready"
+retries=10
+until pg_isready --timeout=1 "${params[@]}" >/dev/null 2>&1
+do
+  sleep 1
+  ((retries=retries-1))
+  if [ $retries -eq 0 ]
+  then
+    echo "Can't connect to PostgreSQL on $POSTGRES_HOST:$POSTGRES_PORT as user ${POSTGRES_USER:-frepple}"
+    exit 1
+  fi
+done
+echo "Connected to PostgreSQL on $POSTGRES_HOST:$POSTGRES_PORT as user ${POSTGRES_USER:-frepple}"
+
+# Create and migrate the databases
+frepplectl createdatabase --skip-if-exists
+frepplectl migrate --noinput
+
+# Configure Apache
+grep -qxF 'ServerName' /etc/apache2/apache2.conf || echo "ServerName localhost" >> /etc/apache2/apache2.conf
+rm -f /usr/local/apache2/logs/httpd.pid
+
+# Allow custom configuration steps to be added
+if [[ -d "/etc/frepple/entrypoint.d" ]]; then
+  /bin/run-parts --verbose "/etc/frepple/entrypoint.d"
+fi
+
+#Start apache web server
+echo "Starting web server"
+exec apachectl -D FOREGROUND
+
+exit 1

--- a/frepple/8/frepple/license.xml
+++ b/frepple/8/frepple/license.xml
@@ -1,0 +1,1 @@
+# placeholder for the frepple enterprise license

--- a/frepple/8/frepple/requirements.txt
+++ b/frepple/8/frepple/requirements.txt
@@ -1,0 +1,28 @@
+cheroot == 8.4.5
+portend == 2.5
+djangorestframework == 3.13.1
+djangorestframework-bulk == 0.2.1
+djangorestframework-filters == 0.10.2
+django-bootstrap3 == 15.0.0
+django-filter == 2.4.0
+html5lib == 1.0.1
+jdcal == 1.4.1
+Markdown == 3.1.1
+openpyxl == 3.0.9
+lxml == 4.9.2
+PyJWT == 2.4.0
+urllib3 < 2
+requests == 2.31.0
+python-dateutil == 2.8.1
+pillow >= 8.4.0
+psutil == 5.7.3
+psycopg2-binary == 2.8.6
+# Python packaging is broken on ubuntu 20 for higher versions of setuptools
+setuptools <= 46.1
+setuptools-rust == 0.12.1
+pysftp == 0.2.9
+channels == 4.0.0
+attrs == 23.1.0
+daphne == 4.0.0
+Twisted[tls,http2]
+https://github.com/frePPLe/django/tarball/frepple_8.0

--- a/frepple/8/frepple/templates/djangosettings.py.tmpl
+++ b/frepple/8/frepple/templates/djangosettings.py.tmpl
@@ -1,0 +1,775 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2007-2015 by frePPLe bv
+#
+# All information contained herein is, and remains the property of frePPLe.
+# You are allowed to use and modify the source code, as long as the software is used
+# within your company.
+# You are not allowed to distribute the software, either in the form of source code
+# or in the form of compiled binaries.
+#
+
+r"""
+Main Django configuration file.
+"""
+import os
+import sys
+
+from django.utils.translation import gettext_lazy as _
+
+try:
+    DEBUG = "runserver" in sys.argv
+except Exception:
+    DEBUG = False
+DEBUG_JS = DEBUG
+
+ADMINS = (
+    # ('{{ default .Env.FREPPLE_ADMIN_NAME "admin@example.com" "false" }}', '{{ default .Env.FREPPLE_ADMIN_EMAIL "admin@example.com" }}'),
+)
+
+# ================= START UPDATED BLOCK BY WINDOWS INSTALLER =================
+# Make this unique, and don't share it with anybody.
+SECRET_KEY = "{{ default .Env.FREPPLE_SECRET_KEY "false" }}"
+
+# FrePPLe only supports the postgresql database.
+# Create additional entries in this dictionary to define scenario schemas.
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        # Database name
+        "NAME": "{{ default .Env.POSTGRES_DBNAME "frepple" }}",
+        # Role name when using md5 authentication.
+        # Leave as an empty string when using peer or
+        # ident authencation.
+        "USER": "{{ default .Env.POSTGRES_USER "frepple" }}",
+        # Role password when using md5 authentication.
+        # Leave as an empty string when using peer or
+        # ident authencation.
+        "PASSWORD": "{{ default .Env.POSTGRES_PASSWORD "frepple" }}",
+        # When using TCP sockets specify the hostname,
+        # the ip4 address or the ip6 address here.
+        # Leave as an empty string to use Unix domain
+        # socket ("local" lines in pg_hba.conf).
+        "HOST": "{{ default .Env.POSTGRES_HOST "localhost" }}",
+        # Specify the port number when using a TCP socket.
+        "PORT": "{{ default .Env.POSTGRES_PORT "5432" }}",
+        "OPTIONS": {{ default .Env.FREPPLE_OPTIONS "{}" }},
+        "CONN_MAX_AGE": {{ default .Env.FREPPLE_CONN_MAX_AGE "60" }},
+        "TEST": {
+            "NAME": "{{ default .Env.FREPPLE_TEST_NAME "test_frepple" }}",  # Database name used when running the test suite.
+            "FREPPLE_PORT": "{{ default .Env.FREPPLE_PORT_DEFAULT "127.0.0.1:9002" }}",
+        },
+        # The FILEUPLOADFOLDER setting is used by the "import data files" task.
+        # By default all scenario databases use the same data folder on the server.
+        # By configuring this setting you can configure a dedicated data folder for each
+        # scenario database.
+        "FILEUPLOADFOLDER": os.path.normpath(
+            os.path.join(FREPPLE_LOGDIR, "data", "default")
+        ),
+        # Role name for executing custom reports and processing sql data files.
+        # Make sure this role has properly restricted permissions!
+        # When left unspecified, SQL statements run with the full read-write
+        # permissions of the user specified above. Which can be handy, but is not secure.
+        "SQL_ROLE": "{{ default .Env.FREPPLE_SQL_ROLE "report_role" }}",
+        "SECRET_WEBTOKEN_KEY": SECRET_KEY,
+        "FREPPLE_PORT": "{{ default .Env.FREPPLE_PORT_DEFAULT "127.0.0.1:8002" }}",
+    },
+    "scenario1": {
+        "ENGINE": "django.db.backends.postgresql",
+        # Database name
+        "NAME": "scenario1",
+        # Role name when using md5 authentication.
+        # Leave as an empty string when using peer or
+        # ident authencation.
+        "USER": "{{ default .Env.POSTGRES_USER "frepple" }}",
+        # Role password when using md5 authentication.
+        # Leave as an empty string when using peer or
+        # ident authencation.
+        "PASSWORD": "{{ default .Env.POSTGRES_PASSWORD "frepple" }}",
+        # When using TCP sockets specify the hostname,
+        # the ip4 address or the ip6 address here.
+        # Leave as an empty string to use Unix domain
+        # socket ("local" lines in pg_hba.conf).
+        "HOST": "{{ default .Env.POSTGRES_HOST "localhost" }}",
+        # Specify the port number when using a TCP socket.
+        "PORT": "{{ default .Env.POSTGRES_PORT "5432" }}",
+        "OPTIONS": {{ default .Env.FREPPLE_OPTIONS "{}" }},
+        "CONN_MAX_AGE": {{ default .Env.FREPPLE_CONN_MAX_AGE "60" }},
+        "TEST": {
+            "NAME": "test_scenario1",  # Database name used when running the test suite.
+            "FREPPLE_PORT": "127.0.0.1:9003",
+        },
+        # The FILEUPLOADFOLDER setting is used by the "import data files" task.
+        # By default all scenario databases use the same data folder on the server.
+        # By configuring this setting you can configure a dedicated data folder for each
+        # scenario database.
+        "FILEUPLOADFOLDER": os.path.normpath(
+            os.path.join(FREPPLE_LOGDIR, "data", "scenario1")
+        ),
+        # Role name for executing custom reports and processing sql data files.
+        # Make sure this role has properly restricted permissions!
+        # When left unspecified, SQL statements run with the full read-write
+        # permissions of the user specified above. Which can be handy, but is not secure.
+        "SQL_ROLE": "{{ default .Env.FREPPLE_SQL_ROLE "report_role" }}",
+        "SECRET_WEBTOKEN_KEY": SECRET_KEY,
+        "FREPPLE_PORT": "{{ default .Env.FREPPLE_PORT_SCENARIO1 "127.0.0.1:8003" }}",
+    },
+    "scenario2": {
+        "ENGINE": "django.db.backends.postgresql",
+        # Database name
+        "NAME": "scenario2",
+        # Role name when using md5 authentication.
+        # Leave as an empty string when using peer or
+        # ident authencation.
+        "USER": "{{ default .Env.POSTGRES_USER "frepple" }}",
+        # Role password when using md5 authentication.
+        # Leave as an empty string when using peer or
+        # ident authencation.
+        "PASSWORD": "{{ default .Env.POSTGRES_PASSWORD "frepple" }}",
+        # When using TCP sockets specify the hostname,
+        # the ip4 address or the ip6 address here.
+        # Leave as an empty string to use Unix domain
+        # socket ("local" lines in pg_hba.conf).
+        "HOST": "{{ default .Env.POSTGRES_HOST "localhost" }}",
+        # Specify the port number when using a TCP socket.
+        "PORT": "{{ default .Env.POSTGRES_PORT "5432" }}",
+        "OPTIONS": {{ default .Env.FREPPLE_OPTIONS "{}" }},
+        "CONN_MAX_AGE": {{ default .Env.FREPPLE_CONN_MAX_AGE "60" }},
+        "TEST": {
+            "NAME": "test_scenario2",  # Database name used when running the test suite.
+            "FREPPLE_PORT": "127.0.0.1:9004",
+        },
+        # The FILEUPLOADFOLDER setting is used by the "import data files" task.
+        # By default all scenario databases use the same data folder on the server.
+        # By configuring this setting you can configure a dedicated data folder for each
+        # scenario database.
+        "FILEUPLOADFOLDER": os.path.normpath(
+            os.path.join(FREPPLE_LOGDIR, "data", "scenario2")
+        ),
+        # Role name for executing custom reports and processing sql data files.
+        # Make sure this role has properly restricted permissions!
+        # When left unspecified, SQL statements run with the full read-write
+        # permissions of the user specified above. Which can be handy, but is not secure.
+        "SQL_ROLE": "{{ default .Env.FREPPLE_SQL_ROLE "report_role" }}",
+        "SECRET_WEBTOKEN_KEY": SECRET_KEY,
+        "FREPPLE_PORT": "{{ default .Env.FREPPLE_PORT_SCENARIO2 "127.0.0.1:8004" }}",
+    },
+    "scenario3": {
+        "ENGINE": "django.db.backends.postgresql",
+        # Database name
+        "NAME": "scenario3",
+        # Role name when using md5 authentication.
+        # Leave as an empty string when using peer or
+        # ident authencation.
+        "USER": "{{ default .Env.POSTGRES_USER "frepple" }}",
+        # Role password when using md5 authentication.
+        # Leave as an empty string when using peer or
+        # ident authencation.
+        "PASSWORD": "{{ default .Env.POSTGRES_PASSWORD "frepple" }}",
+        # When using TCP sockets specify the hostname,
+        # the ip4 address or the ip6 address here.
+        # Leave as an empty string to use Unix domain
+        # socket ("local" lines in pg_hba.conf).
+        "HOST": "{{ default .Env.POSTGRES_HOST "localhost" }}",
+        # Specify the port number when using a TCP socket.
+        "PORT": "{{ default .Env.POSTGRES_PORT "5432" }}",
+        "OPTIONS": {{ default .Env.FREPPLE_OPTIONS "{}" }},
+        "CONN_MAX_AGE": {{ default .Env.FREPPLE_CONN_MAX_AGE "60"}},
+        "TEST": {
+            "NAME": "test_scenario3",  # Database name used when running the test suite.
+            "FREPPLE_PORT": "127.0.0.1:9005",
+        },
+        # The FILEUPLOADFOLDER setting is used by the "import data files" task.
+        # By default all scenario databases use the same data folder on the server.
+        # By configuring this setting you can configure a dedicated data folder for each
+        # scenario database.
+        "FILEUPLOADFOLDER": os.path.normpath(
+            os.path.join(FREPPLE_LOGDIR, "data", "scenario3")
+        ),
+        # Role name for executing custom reports and processing sql data files.
+        # Make sure this role has properly restricted permissions!
+        # When left unspecified, SQL statements run with the full read-write
+        # permissions of the user specified above. Which can be handy, but is not secure.
+        "SQL_ROLE": "{{ default .Env.FREPPLE_SQL_ROLE "report_role" }}",
+        "SECRET_WEBTOKEN_KEY": SECRET_KEY,
+        "FREPPLE_PORT": "{{ default .Env.FREPPLE_PORT_SCENARIO3 "127.0.0.1:8005" }}",
+    },
+}
+
+LANGUAGE_CODE = "{{ default .Env.FREPPLE_LANGUAGE_CODE "en" }}"
+
+# Google analytics code to report usage statistics to.
+# The value None disables this feature.
+GOOGLE_ANALYTICS = {{ default .Env.FREPPLE_GOOGLE_ANALYTICS "None" }}
+
+# Installed applications.
+# The order is important: urls, templates and menus of the earlier entries
+# take precedence over and override later entries.
+INSTALLED_APPS = (
+    (
+        "django.contrib.auth",
+        "django.contrib.contenttypes",
+        "django.contrib.messages",
+        "django.contrib.staticfiles",
+        "freppledb.boot",
+    )
+    + (
+        tuple(os.environ["FREPPLE_APPS"].split(","))
+        if "FREPPLE_APPS" in os.environ
+        else (
+            # Add any project specific apps here
+            "freppledb.wizard",
+            "freppledb.quoting",
+            "freppledb.demandhits",
+            "freppledb.input",
+            "freppledb.forecast",
+            "freppledb.inventoryplanning",
+            "freppledb.shelflife",
+            "freppledb.odoo",
+            # "freppledb.erpconnection",
+            # "freppledb.openbravo",
+            # "freppledb.shopfloor",
+            "freppledb.planningboard",
+            "freppledb.webservice",
+            "freppledb.abc_classification",
+            "freppledb.metrics",
+            "freppledb.archive",
+        )
+    )
+    + (
+        "freppledb.output",
+        "freppledb.execute",
+        "freppledb.common",
+        "django_filters",
+        "rest_framework",
+        "django.contrib.admin",
+        # The next two apps allow users to run their own SQL statements on
+        # the database, using the SQL_ROLE configured above.
+        "freppledb.reportmanager",
+        # "freppledb.executesql",
+        # The next app implements a URL end point for monitoring the
+        # health of the application
+        # "freppledb.monitor",
+        "freppledb.debugreport",
+    )
+)
+# ================= END UPDATED BLOCK BY WINDOWS INSTALLER =================
+
+# A list of user names thatcan generate database dumps and download them.
+# Since a database dump exposes all data, enabling this functionality should only be done
+# for system administrators that know what they are doing.
+SUPPORT_USERS = []
+
+# If passwords are set in this file they will be used instead of the ones set in the database parameters table
+ODOO_PASSWORDS = {
+  "default": "{{ default .Env.FREPPLE_ODOO_PASSWORD_DEFAULT "" }}",
+  "scenario1": "{{ default .Env.FREPPLE_ODOO_PASSWORD_SCENARIO1 "" }}",
+  "scenario2": "{{ default .Env.FREPPLE_ODOO_PASSWORD_SCENARIO2 "" }}",
+  "scenario3": "{{ default .Env.FREPPLE_ODOO_PASSWORD_SCENARIO3 "" }}"
+}
+
+# If passwords are set in this file they will be used instead of the ones set in the database parameters table
+OPENBRAVO_PASSWORDS = {
+  "default": "{{ default .Env.FREPPLE_OPENBRAVO_PASSWORD_DEFAULT "" }}",
+  "scenario1": "{{ default .Env.FREPPLE_OPENBRAVO_PASSWORD_SCENARIO1 "" }}",
+  "scenario2": "{{ default .Env.FREPPLE_OPENBRAVO_PASSWORD_SCENARIO2 "" }}",
+  "scenario3": "{{ default .Env.FREPPLE_OPENBRAVO_PASSWORD_SCENARIO3 "" }}"
+}
+
+# Retrieve the server time zone and use it for the database
+# we need to convert that string into iana/olson format using package tzlocal
+try:
+    from tzlocal import get_localzone
+
+    TIME_ZONE = str(get_localzone())
+except Exception:
+    TIME_ZONE = "{{ default .Env.FREPPLE_TIME_ZONE "America/Phoenix" }}"
+
+# TIME_ZONE can still be overriden by uncommenting following line
+# That will force the database and the server to use that timezone
+# Choices can be found here:
+# http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
+# On Unix systems, a value of None will cause Django to use the same
+# timezone as the operating system.
+# If running in a Windows environment this must be set to the same as your
+# system time zone.
+# TIME_ZONE = "Europe/Brussels"
+
+# tests have to be done in UTC
+if not hasattr(sys, "argv") or "test" in sys.argv:
+    TIME_ZONE = "UTC"
+
+# We provide 3 options for formatting dates (and you always add your own).
+#  - month-day-year: US format
+#  - day-month-year: European format
+#  - year-month-day: international format. This is the default
+DATE_STYLE = "{{ default .Env.FREPPLE_DATE_STYLE "year-month-day" }}"
+
+if DATE_STYLE == "month-date-year":
+    # Option 1: US style
+    DATE_FORMAT = (
+        # see https://docs.djangoproject.com/en/3.2/ref/templates/builtins/#std-templatefilter-date
+        "m/d/Y"
+    )
+    DATETIME_FORMAT = (
+        # see https://docs.djangoproject.com/en/3.2/ref/templates/builtins/#std-templatefilter-date
+        "m/d/Y H:i:s"
+    )
+    DATE_FORMAT_JS = (
+        # see https://bootstrap-datepicker.readthedocs.io/en/latest/options.html#format
+        "MM/DD/YYYY"
+    )
+    DATETIME_FORMAT_JS = (
+        # see https://momentjs.com/docs/#/displaying/
+        "DD_MM_YYYY HH:mm:ss"
+    )
+    DATE_INPUT_FORMATS = [
+        # See https://docs.djangoproject.com/en/3.2/ref/settings/#std-setting-DATE_FORMAT
+        "%m/%d/%Y",
+        "%m/%d/%y",
+        "%m-%d-%Y",
+        "%m-%d-%y",
+        "%b %d %Y",
+        "%b %d, %Y",
+        "%d %b %Y",
+        "%d %b %Y",
+        "%B %d %Y",
+        "%B %d, %Y",
+        "%d %B %Y",
+        "%d %B, %Y",
+    ]
+    DATETIME_INPUT_FORMATS = [
+        # See https://docs.djangoproject.com/en/3.2/ref/settings/#std-setting-DATETIME_FORMAT
+        "%m/%d/%Y %H:%M:%S",
+        "%m-%d-%Y %H:%M:%S",
+        "%m-%d-%Y %H:%M",
+        "%m/%d/%Y %H:%M:%S",
+        "%m/%d/%Y %H:%M",
+        "%m/%d/%y %H:%M:%S",
+        "%m/%d/%y %H:%M",
+    ]
+elif DATE_STYLE == "day-month-year":
+    # Option 2: European style
+    DATE_FORMAT = (
+        # see https://docs.djangoproject.com/en/3.2/ref/templates/builtins/#std-templatefilter-date
+        "d-m-Y"
+    )
+    DATETIME_FORMAT = (
+        # see https://docs.djangoproject.com/en/3.2/ref/templates/builtins/#std-templatefilter-date
+        "d-m-Y H:i:s"
+    )
+    DATE_FORMAT_JS = (
+        # see https://bootstrap-datepicker.readthedocs.io/en/latest/options.html#format
+        "DD-MM-YYYY"
+    )
+    DATETIME_FORMAT_JS = (
+        # see https://momentjs.com/docs/#/displaying/
+        "DD-MM-YYYY HH:mm:ss"
+    )
+    DATE_INPUT_FORMATS = [
+        # See https://docs.djangoproject.com/en/3.2/ref/settings/#std-setting-DATE_FORMAT
+        "%d-%m-%Y",
+        "%d-%m-%y",
+        "%d/%m/%Y",
+        "%d/%m/%y",
+        "%b %d %Y",
+        "%b %d, %Y",
+        "%d %b %Y",
+        "%d %b, %Y",
+        "%B %d %Y",
+        "%B %d, %Y",
+        "%d %B %Y",
+        "%d %B, %Y",
+    ]
+    DATETIME_INPUT_FORMATS = [
+        # See https://docs.djangoproject.com/en/3.2/ref/settings/#std-setting-DATETIME_FORMAT
+        "%d-%m-%Y %H:%M:%S",
+        "%d-%m-%Y %H:%M",
+        "%d/%m/%y %H:%M:%S",
+        "%d/%m/%y %H:%M",
+        "%d/%m/%Y %H:%M:%S",
+        "%f/%m/%Y %H:%M",
+        "%d/%m/%y %H:%M:%S",
+        "%d/%m/%y %H:%M",
+    ]
+else:
+    # Option 3: International style, default
+    DATE_FORMAT = (
+        # see https://docs.djangoproject.com/en/3.2/ref/templates/builtins/#std-templatefilter-date
+        "Y-m-d"
+    )
+    DATETIME_FORMAT = (
+        # see https://docs.djangoproject.com/en/3.2/ref/templates/builtins/#std-templatefilter-date
+        "Y-m-d H:i:s"
+    )
+    DATE_FORMAT_JS = (
+        # see https://bootstrap-datepicker.readthedocs.io/en/latest/options.html#format
+        "YYYY-MM-DD"
+    )
+    DATETIME_FORMAT_JS = (
+        # see https://momentjs.com/docs/#/displaying/
+        "YYYY-MM-DD HH:mm:ss"
+    )
+    DATE_INPUT_FORMATS = [
+        # See https://docs.djangoproject.com/en/3.2/ref/settings/#std-setting-DATE_FORMAT
+        "%Y-%m-%d",
+        "%y-%m-%d",
+        "%Y/%m/%d",
+        "%y/%m/%d",
+        "%b %d %Y",
+        "%b %d, %Y",
+        "%d %b %Y",
+        "%d %b %Y",
+        "%B %d %Y",
+        "%B %d, %Y",
+        "%d %B %Y",
+        "%d %B, %Y",
+    ]
+    DATETIME_INPUT_FORMATS = [
+        # See https://docs.djangoproject.com/en/3.2/ref/settings/#std-setting-DATETIME_FORMAT
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d %H:%M",
+        "%y-%m-%d %H:%M:%S",
+        "%y-%m-%d %H:%M",
+        "%Y/%m/%d %H:%M:%S",
+        "%Y/%m/%d %H:%M",
+        "%y/%m/%d %H:%M:%S",
+        "%y/%m/%d %H:%M",
+    ]
+
+
+# Supported language codes, sorted by language code.
+# Language names and codes should match the ones in Django.
+# You can see the list supported by Django at:
+#    https://github.com/django/django/blob/master/django/conf/global_settings.py
+LANGUAGES = (
+    ("en", _("English")),
+    ("fr", _("French")),
+    ("de", _("German")),
+    ("he", _("Hebrew")),
+    ("hr", _("Croatian")),
+    ("it", _("Italian")),
+    ("ja", _("Japanese")),
+    ("nl", _("Dutch")),
+    ("pt", _("Portuguese")),
+    ("pt-br", _("Brazilian Portuguese")),
+    ("ru", _("Russian")),
+    ("es", _("Spanish")),
+    ("zh-hans", _("Simplified Chinese")),
+    ("zh-hant", _("Traditional Chinese")),
+    ("uk", _("Ukrainian")),
+)
+
+# The remember-me checkbox on the login page allows to keep a session cookie
+# active in your browser. The session will expire after the age configured
+# in the setting below (epxressed in seconds).
+# Set the value to 0 to force users to log in for every browser session.
+SESSION_COOKIE_AGE = {{ default .Env.FREPPLE_SESSION_COOKIE_AGE "3600 * 24 * 3" }}  # 3 days
+
+# Users are automatically logged out after this period of inactivity
+SESSION_LOGOUT_IDLE_TIME = {{ default .Env.FREPPLE_SESSION_LOGOUT_IDLE_TIME "60" }}  # minutes
+
+LOGO = "frepple.svg"
+LOGO_LOGIN = LOGO
+
+MIDDLEWARE = (
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    # Uncomment the next line to automatically log on as the admin user,
+    # which can be useful for development or for demo models.
+    # "freppledb.common.middleware.AutoLoginAsAdminUser",
+    "freppledb.common.middleware.MultiDBMiddleware",
+    # Optional: The following middleware allows authentication with HTTP headers
+    "freppledb.common.middleware.HTTPAuthenticationMiddleware",
+    "freppledb.common.middleware.LocaleMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    # Optional used to prevent user from accessing the application
+    # "freppledb.retail.middleware.MaintenanceMiddleware",
+)
+
+# Custom attribute fields in the database
+# After each change of this setting, the following commands MUST be
+# executed to create the fields in the database(s).
+#   frepplectl makemigrations
+#   frepplectl migrate     OR     frepplectl migrate --database DATABASE
+#
+# The commands will create migration files to keep track of the changes.
+# You MUST use the above commands and the generated migration scripts. Manually
+# changing the database schema will work in simple cases, but will get you
+# in trouble in the long run!
+# You'll need write permissions in the folder where these are stored.
+#
+# See https://docs.djangoproject.com/en/1.8/topics/migrations/ for the
+# details on the migration files. For complex changes to the attributes
+# an administrator may need to edit, delete or extend these files.
+#
+# Supported field types are 'string', 'boolean', 'number', 'integer',
+# 'date', 'datetime', 'duration' and 'time'.
+# Example:
+#  ATTRIBUTES = [
+#    ('freppledb.input.models.Item', [
+#      ('attribute1', ugettext('attribute_1'), 'string'),
+#      ('attribute2', ugettext('attribute_2'), 'boolean'),
+#      ('attribute3', ugettext('attribute_3'), 'date'),
+#      ('attribute4', ugettext('attribute_4'), 'datetime'),
+#      ('attribute5', ugettext('attribute_5'), 'number'),
+#      ]),
+#    ('freppledb.input.models.Operation', [
+#      ('attribute1', ugettext('attribute_1'), 'string'),
+#      ])
+#    ]
+ATTRIBUTES = {{ default .Env.FREPPLE_ATTRIBUTES "[]" }}
+
+# Memory cache
+CACHE_GRID_COUNT = {{ default .Env.FREPPLE_CACHE_GRID_COUNT "None" }}
+CACHE_PIVOT_COUNT = {{ default .Env.FREPPLE_CACHE_PIVOT_COUNT "None" }}
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    }
+}
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": True,
+    "filters": {"require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}},
+    "formatters": {
+        "verbose": {
+            "format": "%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s"
+        },
+        "simple": {"format": "%(levelname)s %(message)s"},
+    },
+    "handlers": {
+        "null": {"level": "DEBUG", "class": "logging.NullHandler"},
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "simple",
+        },
+        "mail_admins": {
+            "level": "CRITICAL",
+            "filters": ["require_debug_false"],
+            "class": "django.utils.log.AdminEmailHandler",
+        },
+    },
+    "loggers": {
+        # A handler to log all SQL queries.
+        # The setting "DEBUG" also needs to be set to True higher up in this file.
+        # "django.db.backends": {
+        #     "handlers": ["console"],
+        #     "level": "DEBUG",
+        #     "propagate": False,
+        # },
+        "django": {"handlers": ["console"], "level": "INFO"},
+        "freppledb": {"handlers": ["console"], "level": "INFO"},
+        "freppleapps": {"handlers": ["console"], "level": "INFO"},
+    },
+}
+
+# Maximum allowed memory size for the planning engine. Only used on Linux!
+MAXMEMORYSIZE = {{ default .Env.FREPPLE_MAXMEMORYSIZE "None" }}  # limit in MB, minimum around 230, use None for unlimited
+
+# Maximum allowed memory size for the planning engine. Only used on Linux!
+MAXCPUTIME = {{ default .Env.FREPPLE_MAXCPUTIME "None" }}  # limit in seconds, use None for unlimited
+
+# Specify number of objects we are allowed to cache and the number of
+# threads we create to write changed objects
+CACHE_MAXIMUM = {{ default .Env.FREPPLE_CACHE_MAXIMUM "1000000" }}
+CACHE_THREADS = {{ default .Env.FREPPLE_CACHE_THREADS "3" }}
+
+# Max total log files size in MB, if the limit is reached deletes the oldest.
+MAXTOTALLOGFILESIZE = {{ default .Env.FREPPLE_MAXTOTALLOGFILESIZE "200" }}
+
+# A list of available user interface themes.
+# If multiple themes are configured in this list, the user's can change their
+# preferences among the ones listed here.
+# If the list contains only a single value, the preferences screen will not
+# display users an option to choose the theme.
+THEMES = [
+    "earth",
+    "grass",
+    "lemon",
+    "odoo",
+    "openbravo",
+    "orange",
+    "snow",
+    "strawberry",
+    "water",
+]
+
+# A default user-group to which new users are automatically added
+DEFAULT_USER_GROUP = {{ default .Env.FREPPLE_DEFAULT_USER_GROUP "None" }}
+
+# The default user interface theme
+DEFAULT_THEME = "{{ default .Env.FREPPLE_DEFAULT_THEME "earth" }}"
+
+# The default number of records to pull from the server as a page
+DEFAULT_PAGESIZE = {{ default .Env.FREPPLE_DEFAULT_PAGESIZE "100" }}
+
+# Configuration of the default dashboard
+DEFAULT_DASHBOARD = [
+    {
+        "rowname": _("Welcome"),
+        "cols": [
+            {"width": 8, "widgets": [("inbox", {"limit": 10})]},
+            {"width": 4, "widgets": [("news", {})]},
+        ],
+    },
+    {
+        "rowname": _("sales"),
+        "cols": [
+            {
+                "width": 9,
+                "widgets": [
+                    ("forecast", {"history": 36, "future": 12}),
+                    (
+                        "analysis_demand_problems",
+                        {"top": 20, "orderby": "latedemandvalue"},
+                    ),
+                    ("outliers", {"limit": 20}),
+                ],
+            },
+            {
+                "width": 3,
+                "widgets": [
+                    ("demand_alerts", {}),
+                    ("delivery_performance", {"green": 90, "yellow": 80}),
+                    ("archived_demand", {"history": 12}),
+                    ("forecast_error", {"history": 12}),
+                ],
+            },
+        ],
+    },
+    {
+        "rowname": _("purchasing"),
+        "cols": [
+            {
+                "width": 9,
+                "widgets": [
+                    ("purchase_orders", {"fence1": 7, "fence2": 30}),
+                    # ("purchase_queue",{"limit":20}),
+                    ("purchase_order_analysis", {"limit": 20}),
+                ],
+            },
+            {
+                "width": 3,
+                "widgets": [
+                    ("archived_purchase_order", {"history": 12}),
+                    ("inventory_by_location", {"limit": 5}),
+                    ("inventory_by_item", {"limit": 10}),
+                ],
+            },
+        ],
+    },
+    {
+        "rowname": _("distribution"),
+        "cols": [
+            {
+                "width": 12,
+                "widgets": [
+                    ("distribution_orders", {"fence1": 7, "fence2": 30}),
+                    # ("shipping_queue",{"limit":20}),
+                    ("archived_buffer", {"history": 12}),
+                    ("inventorystatus", {"green": 30, "yellow": 50}),
+                ],
+            }
+        ],
+    },
+    {
+        "rowname": _("manufacturing"),
+        "cols": [
+            {
+                "width": 9,
+                "widgets": [
+                    ("manufacturing_orders", {"fence1": 7, "fence2": 30}),
+                    # ("resource_queue",{"limit":20}),
+                ],
+            },
+            {
+                "width": 3,
+                "widgets": [
+                    ("capacity_alerts", {}),
+                    ("resource_utilization", {"limit": 5, "medium": 80, "high": 90}),
+                ],
+            },
+        ],
+    },
+]
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        "OPTIONS": {"min_length": 8},
+    },
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
+]
+
+# Configuration of SMTP mail server
+EMAIL_USE_TLS = {{ default .Env.FREPPLE_EMAIL_USE_TLS "True" }}
+DEFAULT_FROM_EMAIL = "{{ default .Env.FREPPLE_DEFAULT_FROM_EMAIL "your_email@domain.com" }}"
+SERVER_EMAIL = "{{ default .Env.FREPPLE_SERVER_EMAIL "your_email@domain.com" }}"
+EMAIL_HOST_USER = "{{ default .Env.FREPPLE_EMAIL_HOST_USER "your_email@domain.com" }}"
+EMAIL_HOST_PASSWORD = "{{ default .Env.FREPPLE_EMAIL_HOST_PASSWORD "frePPLeIsTheBest" }}"
+EMAIL_HOST = {{ default .Env.FREPPLE_EMAIL_HOST "None" }}
+EMAIL_PORT = {{ default .Env.FREPPLE_EMAIL_PORT "25" }}
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+
+# Clickjacking security http headers
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+# Default: allow content from same domain
+CONTENT_SECURITY_POLICY = "frame-ancestors 'self'"
+X_FRAME_OPTIONS = "SAMEORIGIN"
+# Alternative: prohibit embedding in any frame
+#   CONTENT_SECURITY_POLICY = "frame-ancestors 'none'"
+#   X_FRAME_OPTIONS = "DENY"
+# Alternative: allow embedding in a specific domain
+#   CONTENT_SECURITY_POLICY = "frame-ancestors 'self' mydomain.com;"
+#   X_FRAME_OPTIONS = None
+#   SESSION_COOKIE_SAMESITE = "none"
+#   CSRF_COOKIE_SAMESITE = "none"
+
+# Configuration of the ftp/sftp/ftps server where to upload reports
+# Note that for SFTP protocol, the host needs to be defined
+# in the known_hosts file
+# These variables can either be a string if common to all scenarios
+# or a dictionary if they vary per scenario (see FTP_FOLDER EXAMPLE)
+FTP_PROTOCOL = "{{ default .Env.FREPPLE_FTP_PROTOCOL "SFTP" }}"  # supported protocols are SFTP, FTPS and FTP (unsecure)
+FTP_HOST = {{ default .Env.FREPPLE_FTP_HOST "None" }}
+FTP_PORT = {{ default .Env.FREPPLE_FTP_PORT "22" }}
+FTP_USER = {{ default .Env.FREPPLE_FTP_PASSWORD "None" }}
+FTP_PASSWORD = {{ default .Env.FREPPLE_FTP_PASSWORD "None" }}
+FTP_FOLDER = {
+    "default": {{ default .Env.FREPPLE_FTP_FOLDER_DEFAULT "None" }},
+    "scenario1": {{ default .Env.FREPPLE_FTP_FOLDER_SCENARIO1 "None" }},
+    "scenario2": {{ default .Env.FREPPLE_FTP_FOLDER_SCENARIO2 "None" }},
+    "scenario3": {{ default .Env.FREPPLE_FTP_FOLDER_SCENARIO3 "None" }},
+}  # folder where the files should be uploaded on the remote server
+
+GLOBAL_PREFERENCES = {
+    "freppledb.planningboard": set(
+        [
+            "colorbycriticality",
+            "colorbypriority",
+            "colorbydelay",
+            "colorbyitemcat",
+            "colorbyitemsubcat",
+            "colorbyduedate",
+            "colorbyoperationcat",
+            "colorbyoperationsubcat",
+        ]
+    )
+}
+
+# Port number when not using Apache
+PORT = {{ default .Env.FREPPLE_PORT "8000" }}
+
+# Browser to test with selenium
+SELENIUM_TESTS = "{{ default .Env.FREPPLE_SELENIUM_TESTS "chrome" }}"
+SELENIUM_HEADLESS = {{ default .Env.FREPPLE_SELENIUM_HEADLESS "True" }}


### PR DESCRIPTION
Adding frePPLe version 8. Now uses the docker image put out by frePPLe themselves rather than building from the Debian.

-------------------------------------------------------------------
Squashed commits:

adding frepple 8

Fixed template, db connection works, saving progress

Frepple now starts and runs correctl, need ot clean up repo, commit to save progress

Cleaned up frePPLe 8 work and directory

Clean docker compose of company references