### PR TITLE
[IMP] Odoo 19: add demo RUNNING_ENV to create a database with demo data

### DIFF
--- a/odoo/19.0/entrypoint.sh
+++ b/odoo/19.0/entrypoint.sh
@@ -166,7 +166,7 @@ function upgrade_existing() {
   DATABASES=$(psql -X -A -t $DEFAULTDB -c "
     SELECT datname
     FROM pg_database
-    WHERE datname not in ('master', 'backup', 'latest', 'postgres', 'azure_maintenance', 'azure_sys', '_dodb', 'defaultdb', 'rdsadmin', 'template0', 'template1')";)
+    WHERE datname not in ('master', 'backup', 'demo', 'latest', 'postgres', 'azure_maintenance', 'azure_sys', '_dodb', 'defaultdb', 'rdsadmin', 'template0', 'template1')";)
   for DB_NAME in $DATABASES; do
     echo "Upgrading $DB_NAME"
     migrate $DB_NAME
@@ -218,6 +218,11 @@ elif [ ${MIGRATE,,} == "true" ]; then
     "test")
       upgrade_existing
       duplicate $(date -u +'%Y%m%d')
+      ;;
+    "demo")
+      sed -i -e 's/with_demo = False/with_demo = True/g' $ODOO_RC
+      create demo
+      migrate demo
       ;;
     "dev")
       drop latest


### PR DESCRIPTION
## Summary

- Adds a new `demo` value for `RUNNING_ENV` in the Odoo 19 entrypoint script
- When `RUNNING_ENV=demo`, a database named `demo` is created (if it doesn't exist) with Odoo demo data enabled (`with_demo = True`)
- Excludes the `demo` database from `upgrade_existing` so it is not touched when running `qa` or `test` environments

## Test plan

- [x] Set `RUNNING_ENV=demo` and start the container — verify a `demo` database is created in PostgreSQL
- [x] Verify demo data is present in the `demo` database after initialization
- [x] Set `RUNNING_ENV=qa` or `RUNNING_ENV=test` and confirm the `demo` database is not upgraded by `upgrade_existing`
- [x] Restart the container with `RUNNING_ENV=demo` — verify the existing `demo` database is preserved (not dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)